### PR TITLE
Missing rows patch

### DIFF
--- a/mods/config.py
+++ b/mods/config.py
@@ -140,7 +140,7 @@ interpolate = False
 # common defaults
 model_name_all = list_dir(app_models, '*.zip')
 model_name = 'model-default'
-fill_missing_rows = True                        # fills missing rows in time series data
+fill_missing_rows_in_timeseries = True                        # fills missing rows in time series data
 
 # Evaluation metrics on real values
 eval_metrics = ['SMAPE', 'R2', 'COSINE']    # 'MAPE', 'RMSE'

--- a/mods/config.py
+++ b/mods/config.py
@@ -140,6 +140,7 @@ interpolate = False
 # common defaults
 model_name_all = list_dir(app_models, '*.zip')
 model_name = 'model-default'
+fill_missing_rows = True                        # fills missing rows in time series data
 
 # Evaluation metrics on real values
 eval_metrics = ['SMAPE', 'R2', 'COSINE']    # 'MAPE', 'RMSE'

--- a/mods/models/api.py
+++ b/mods/models/api.py
@@ -138,7 +138,7 @@ def predict_file(*args, **kwargs):
                 skipfooter=skipfooter,
                 engine='python',
                 header=header,
-                fill_missing_rows=True
+                fill_missing_rows=cfg.fill_missing_rows
             )
 
             predictions = m.predict(df_data)
@@ -224,7 +224,7 @@ def predict_data(*args, **kwargs):
                 skipfooter=skipfooter,
                 engine='python',
                 header=header,
-                fill_missing_rows=True
+                fill_missing_rows=cfg.fill_missing_rows
             )
 
             predictions = m.predict(df_data)

--- a/mods/models/api.py
+++ b/mods/models/api.py
@@ -137,7 +137,8 @@ def predict_file(*args, **kwargs):
                 skiprows=skiprows,
                 skipfooter=skipfooter,
                 engine='python',
-                header=header
+                header=header,
+                fill_missing_rows=True
             )
 
             predictions = m.predict(df_data)
@@ -222,7 +223,8 @@ def predict_data(*args, **kwargs):
                 skiprows=skiprows,
                 skipfooter=skipfooter,
                 engine='python',
-                header=header
+                header=header,
+                fill_missing_rows=True
             )
 
             predictions = m.predict(df_data)

--- a/mods/models/api.py
+++ b/mods/models/api.py
@@ -138,7 +138,7 @@ def predict_file(*args, **kwargs):
                 skipfooter=skipfooter,
                 engine='python',
                 header=header,
-                fill_missing_rows=cfg.fill_missing_rows_in_timeseries
+                fill_missing_rows_in_timeseries=cfg.fill_missing_rows_in_timeseries
             )
 
             predictions = m.predict(df_data)
@@ -224,7 +224,7 @@ def predict_data(*args, **kwargs):
                 skipfooter=skipfooter,
                 engine='python',
                 header=header,
-                fill_missing_rows=cfg.fill_missing_rows_in_timeseries
+                fill_missing_rows_in_timeseries=cfg.fill_missing_rows_in_timeseries
             )
 
             predictions = m.predict(df_data)

--- a/mods/models/api.py
+++ b/mods/models/api.py
@@ -138,7 +138,7 @@ def predict_file(*args, **kwargs):
                 skipfooter=skipfooter,
                 engine='python',
                 header=header,
-                fill_missing_rows=cfg.fill_missing_rows
+                fill_missing_rows=cfg.fill_missing_rows_in_timeseries
             )
 
             predictions = m.predict(df_data)
@@ -224,7 +224,7 @@ def predict_data(*args, **kwargs):
                 skipfooter=skipfooter,
                 engine='python',
                 header=header,
-                fill_missing_rows=cfg.fill_missing_rows
+                fill_missing_rows=cfg.fill_missing_rows_in_timeseries
             )
 
             predictions = m.predict(df_data)

--- a/mods/models/mods_model.py
+++ b/mods/models/mods_model.py
@@ -754,7 +754,7 @@ class mods_model:
     def read_file_or_buffer(self, *args, **kwargs):
         if kwargs is not None:
             kwargs = {k: v for k, v in kwargs.items() if k in [
-                'usecols', 'sep', 'skiprows', 'skipfooter', 'engine', 'header', 'fill_missing_rows'
+                'usecols', 'sep', 'skiprows', 'skipfooter', 'engine', 'header', 'fill_missing_rows_in_timeseries'
             ]}
 
             if 'usecols' in kwargs:
@@ -777,8 +777,8 @@ class mods_model:
         df = pd.read_csv(*args, **kwargs)
 
         if kwargs is not None \
-                and 'fill_missing_rows' in kwargs\
-                and kwargs['fill_missing_rows'] is True:
+                and 'fill_missing_rows_in_timeseries' in kwargs \
+                and kwargs['fill_missing_rows_in_timeseries'] is True:
             df = utl.fill_missing_rows(df)
 
         return df

--- a/mods/models/mods_model.py
+++ b/mods/models/mods_model.py
@@ -750,26 +750,22 @@ class mods_model:
 
         return pred_invtrans
 
-    # This function wraps pandas._read_csv(), reads the csv data and calls predict() on them
+    # This function wraps pandas._read_csv() and reads the csv data
     def read_file_or_buffer(self, *args, **kwargs):
-
         try:
             fill_missing_rows_in_timeseries = kwargs['fill_missing_rows_in_timeseries']
         except Exception:
             fill_missing_rows_in_timeseries = False
-
         if kwargs is not None:
             kwargs = {k: v for k, v in kwargs.items() if k in [
                 'usecols', 'sep', 'skiprows', 'skipfooter', 'engine', 'header'
             ]}
-
             if 'usecols' in kwargs:
                 if isinstance(kwargs['usecols'], str):
                     kwargs['usecols'] = [
                         utl.parse_int_or_str(col)
                         for col in kwargs['usecols'].split(',')
                     ]
-
             if 'header' in kwargs:
                 if isinstance(kwargs['header'], str):
                     kwargs['header'] = [
@@ -779,14 +775,12 @@ class mods_model:
                     if len(kwargs['header']) == 1:
                         kwargs['header'] = kwargs['header'][0]
             # print('HEADER: %s' % kwargs['pd_header'])
-
         df = pd.read_csv(*args, **kwargs)
-
         if fill_missing_rows_in_timeseries is True:
             df = utl.fill_missing_rows(df)
-
         return df
 
+    # TODO: delete
     # not used:
     # def predict_file_or_buffer(self, *args, **kwargs):
     #     df = self.read_file_or_buffer(*args, **kwargs)

--- a/mods/models/mods_model.py
+++ b/mods/models/mods_model.py
@@ -752,9 +752,15 @@ class mods_model:
 
     # This function wraps pandas._read_csv(), reads the csv data and calls predict() on them
     def read_file_or_buffer(self, *args, **kwargs):
+
+        try:
+            fill_missing_rows_in_timeseries = kwargs['fill_missing_rows_in_timeseries']
+        except Exception:
+            fill_missing_rows_in_timeseries = False
+
         if kwargs is not None:
             kwargs = {k: v for k, v in kwargs.items() if k in [
-                'usecols', 'sep', 'skiprows', 'skipfooter', 'engine', 'header', 'fill_missing_rows_in_timeseries'
+                'usecols', 'sep', 'skiprows', 'skipfooter', 'engine', 'header'
             ]}
 
             if 'usecols' in kwargs:
@@ -776,9 +782,7 @@ class mods_model:
 
         df = pd.read_csv(*args, **kwargs)
 
-        if kwargs is not None \
-                and 'fill_missing_rows_in_timeseries' in kwargs \
-                and kwargs['fill_missing_rows_in_timeseries'] is True:
+        if fill_missing_rows_in_timeseries is True:
             df = utl.fill_missing_rows(df)
 
         return df

--- a/mods/models/mods_model.py
+++ b/mods/models/mods_model.py
@@ -754,7 +754,7 @@ class mods_model:
     def read_file_or_buffer(self, *args, **kwargs):
         if kwargs is not None:
             kwargs = {k: v for k, v in kwargs.items() if k in [
-                'usecols', 'sep', 'skiprows', 'skipfooter', 'engine', 'header'
+                'usecols', 'sep', 'skiprows', 'skipfooter', 'engine', 'header', 'fill_missing_rows'
             ]}
 
             if 'usecols' in kwargs:
@@ -775,11 +775,18 @@ class mods_model:
             # print('HEADER: %s' % kwargs['pd_header'])
 
         df = pd.read_csv(*args, **kwargs)
+
+        if kwargs is not None \
+                and 'fill_missing_rows' in kwargs\
+                and kwargs['fill_missing_rows'] is True:
+            df = utl.fill_missing_rows(df)
+
         return df
 
-    def predict_file_or_buffer(self, *args, **kwargs):
-        df = self.read_file_or_buffer(*args, **kwargs)
-        return self.predict(df)
+    # not used:
+    # def predict_file_or_buffer(self, *args, **kwargs):
+    #     df = self.read_file_or_buffer(*args, **kwargs)
+    #     return self.predict(df)
 
     def predict_url(self, url):
         pass

--- a/mods/utils.py
+++ b/mods/utils.py
@@ -680,9 +680,9 @@ def fix_missing_num_values(df, cols=None):
 # @stevo
 def estimate_window_spec(df):
     tmpdf = df[['window_start', 'window_end']]
-    window_duration = tmpdf['window_start'].diff()[1:].min()
+    slide_duration = tmpdf['window_start'].diff()[1:].min()
     row1 = tmpdf[:1]
-    slide_duration = row1.window_end[:1].iloc[0] - row1.window_start[:1].iloc[0]
+    window_duration = row1.window_end[:1].iloc[0] - row1.window_start[:1].iloc[0]
     return window_duration, slide_duration
 
 
@@ -706,6 +706,7 @@ def fill_missing_rows(df, range_beg=None, range_end=None):
     """
     if not ('window_start' in df.columns and 'window_end'):
         return df
+    numrows = len(df.index)
     # convert cols to datetime
     df = df.apply(lambda x: pd.to_datetime(x) if x.name in ['window_start', 'window_end'] else x)
     # estimate window specification
@@ -733,4 +734,7 @@ def fill_missing_rows(df, range_beg=None, range_end=None):
     df = df.reset_index(level=0)
     # compute window_end values for the newly added rows (not necessary at the moment)
     df['window_end'] = df['window_start'] + window_duration
+    newnumrows = len(df.index)
+    if newnumrows > numrows:
+        print('filled %d missing rows (was %d)' % (newnumrows - numrows, numrows))
     return df

--- a/mods/utils.py
+++ b/mods/utils.py
@@ -676,6 +676,7 @@ def fix_missing_num_values(df, cols=None):
         df.interpolate(inplace=True)
     return df
 
+
 # @stevo
 def estimate_window_spec(df):
     tmpdf = df[['window_start', 'window_end']]
@@ -703,31 +704,33 @@ def fill_missing_rows(df, range_beg=None, range_end=None):
     pandas.DataFrame
         DataFrame filled with missing rows
     """
-    if not('window_start' in df.columns and 'window_end'):
+    if not ('window_start' in df.columns and 'window_end'):
         return df
-	# convert cols to datetime
-	df = df.apply(lambda x: pd.to_datetime(x) if x.name in ['window_start', 'window_end'] else x)
-	# estimate window specification
-	window_duration, slide_duration = estimate_window_spec(df)
-	tz = df[:1]['window_start'].iloc[0].tzinfo
-	if range_beg:
-		range_beg=pd.Timestamp(range_beg, tzinfo=tz)
-		if range_beg < df[:1]['window_start'].iloc[0]:
-			df = df.shift()
-			df.loc[0, 'window_start'] = range_beg
-			df.loc[0, 'window_end'] = range_beg + window_duration
-	if range_end:
-		range_end=pd.Timestamp(range_end, tzinfo=tz)
-		if range_end > df[-1:]['window_end'].iloc[0]:
-			df = df.append(pd.Series(), ignore_index=True)
-			df.loc[df.index[-1], 'window_start'] = range_end - window_duration
-			df.loc[df.index[-1], 'window_end'] = range_end
-	# set df index
-	df = df.set_index('window_start')
-	# fill missing rows using slide_duration as the frequency
-	df = df.asfreq(slide_duration)
-	# reset index to use window_start as a column
-	df = df.reset_index(level=0)
-	# compute window_end values for the newly added rows (not necessary at the moment)
-	df['window_end'] = df['window_start'] + window_duration
-	return df
+    # convert cols to datetime
+    df = df.apply(lambda x: pd.to_datetime(x) if x.name in ['window_start', 'window_end'] else x)
+    # estimate window specification
+    window_duration, slide_duration = estimate_window_spec(df)
+    tz = df[:1]['window_start'].iloc[0].tzinfo
+    if range_beg:
+        range_beg = pd.Timestamp(range_beg, tzinfo=tz)
+        if range_beg < df[:1]['window_start'].iloc[0]:
+            # add the first row for the specified range to fill from
+            df = df.shift()
+            df.loc[0, 'window_start'] = range_beg
+            df.loc[0, 'window_end'] = range_beg + window_duration
+    if range_end:
+        range_end = pd.Timestamp(range_end, tzinfo=tz)
+        if range_end > df[-1:]['window_end'].iloc[0]:
+            # add the last row for the specified range to fill to
+            df = df.append(pd.Series(), ignore_index=True)
+            df.loc[df.index[-1], 'window_start'] = range_end - window_duration
+            df.loc[df.index[-1], 'window_end'] = range_end
+    # set df index
+    df = df.set_index('window_start')
+    # fill missing rows using slide_duration as the frequency
+    df = df.asfreq(slide_duration)
+    # reset index to use window_start as a column
+    df = df.reset_index(level=0)
+    # compute window_end values for the newly added rows (not necessary at the moment)
+    df['window_end'] = df['window_start'] + window_duration
+    return df

--- a/mods/utils.py
+++ b/mods/utils.py
@@ -565,7 +565,7 @@ def datapool_read(
                     engine='python',
                 )
 
-                if cfg.fill_missing_rows:
+                if cfg.fill_missing_rows_in_timeseries:
                     # fill missing rows for the loaded day
                     range_beg = '%d-%02d-%2d' % (year, month, day)
                     range_end = str(expand_to_datetime(year, month, day) + relativedelta(days=+1))

--- a/mods/utils.py
+++ b/mods/utils.py
@@ -541,12 +541,12 @@ def datapool_read(
                 if not f.startswith(ws):
                     continue
 
+                year = int(rematch.group('year'))
+                month = int(rematch.group('month'))
+                day = int(rematch.group('day'))
+
                 # exclusion filter
-                dpt = datetime.datetime(
-                    int(rematch.group('year')),
-                    int(rematch.group('month')),
-                    int(rematch.group('day'))
-                )
+                dpt = datetime.datetime(year, month, day)
 
                 data_file = os.path.join(root, f)
                 if exclude(dpt, excluded) or not is_within_range(dpt, time_range):
@@ -564,6 +564,16 @@ def datapool_read(
                     skipfooter=0,
                     engine='python',
                 )
+
+                if cfg.fill_missing_rows:
+                    # fill missing rows for the loaded day
+                    range_beg = '%d-%02d-%2d' % (year, month, day)
+                    range_end = str(expand_to_datetime(year, month, day) + relativedelta(days=+1))
+                    df = fill_missing_rows(
+                        df,
+                        range_beg=range_beg,
+                        range_end=range_end
+                    )
 
                 if df_protocol is None:
                     df_protocol = df

--- a/mods/utils.py
+++ b/mods/utils.py
@@ -567,7 +567,7 @@ def datapool_read(
 
                 if cfg.fill_missing_rows_in_timeseries:
                     # fill missing rows for the loaded day
-                    range_beg = '%d-%02d-%2d' % (year, month, day)
+                    range_beg = '%d-%02d-%02d' % (year, month, day)
                     range_end = str(expand_to_datetime(year, month, day) + relativedelta(days=+1))
                     df = fill_missing_rows(
                         df,

--- a/mods/utils.py
+++ b/mods/utils.py
@@ -684,9 +684,9 @@ def fill_missing_rows(df, range_beg=None, range_end=None):
     df : pandas.DataFrame
         Data
     range_beg : str
-        Time range begin in 'YYYY-MM-DD hh:mm:ss.sss' format (default is None)
+        Time range begin in 'YYYY-MM-DD hh:mm:ss' format (default is None)
     range_end : str
-        Time range end in 'YYYY-MM-DD hh:mm:ss.sss' format (default is None)
+        Time range end in 'YYYY-MM-DD hh:mm:ss' format (default is None)
 
     Returns
     -------


### PR DESCRIPTION
Fills missing rows in time series with NaN rows, which fixes the 

- to use it, set `cfg.fill_missing_rows_in_timeseries = True` in [mods/config.py](https://github.com/deephdc/mods/tree/master/mods/config.py)
- window_duration and slide_duration is infered from the data
- both for train and prediction on data loading

## Example
### before
```csv
2019-03-31T01:40:00.000Z	2019-03-31T02:40:00.000Z	557	
2019-03-31T01:50:00.000Z	2019-03-31T02:50:00.000Z	410	
2019-03-31T02:10:00.000Z	2019-03-31T03:10:00.000Z	462	
2019-03-31T02:20:00.000Z	2019-03-31T03:20:00.000Z	1645	
```
### after
```csv
2019-03-31 01:40:00+00:00	2019-03-31 02:40:00+00:00	557.0	
2019-03-31 01:50:00+00:00	2019-03-31 02:50:00+00:00	410.0	
2019-03-31 02:00:00+00:00	2019-03-31 03:00:00+00:00	nan	
2019-03-31 02:10:00+00:00	2019-03-31 03:10:00+00:00	462.0	
2019-03-31 02:20:00+00:00	2019-03-31 03:20:00+00:00	1645.0	
```