### PR TITLE
deepaas installed in DEEP-OC-mods through PyPi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,5 @@ statsmodels
 scikit-learn
 matplotlib
 seaborn
-deepaas>=0.5.1
 pyyaml
 joblib


### PR DESCRIPTION
- deepaas is installed in the docker image instead